### PR TITLE
feat/handle subsequent invocations with spec runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change Log
+
+## 1.3.0
+
+- Add hack to handle subsequent invocations using spec runners by stripping strings 'bundle', 'exec', 'rspec-preloader', 'rspec'

--- a/lib/rspec_preloader/spec_runner.rb
+++ b/lib/rspec_preloader/spec_runner.rb
@@ -31,6 +31,8 @@ class RspecPreloader
     end
 
     def run_specs(arguments_array)
+      # NOTE: Hack to allow subsequent spec runner invocations to work
+      arguments_array.reject! { |arg| ['bundle', 'exec', 'rspec-preloader', 'rspec'].include?(arg) }
       RSpec::Core::Runner.run(arguments_array, @std_err, @std_out)
     end
 

--- a/rspec_preloader.gemspec
+++ b/rspec_preloader.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name        = 'rspec-preloader'
-  gem.version     = '1.2.0'
+  gem.version     = '1.3.0'
   gem.licenses    = ['MIT']
   gem.summary     = "Start Rspec instantly"
   gem.description = "Life is too short to be waiting for your tests to load."


### PR DESCRIPTION
**Context:**
This PR provides a slight quality-of-life improvement for users using spec runners.
Usually, a spec runner will automatically send the full spec command to the terminal. This results in the following error:
![Screenshot 2022-11-09 at 12 28 04 PM](https://user-images.githubusercontent.com/31978393/200738735-456ec923-56d4-4758-9936-ece4de8fedd4.png)

`rspec-preloader` is expecting a space-separated list of spec files, e.g. `spec/guardhouse/workers/update_email_notification_worker_spec.rb`, but receives `rspec spec/guardhouse/workers/update_email_notification_worker_spec.rb` instead.